### PR TITLE
Fix CAS gateway option handling

### DIFF
--- a/integrationTest/suite.sh
+++ b/integrationTest/suite.sh
@@ -1,41 +1,65 @@
 #!/bin/bash
 set -e
 
+keycloak_cas_url='http://localhost:8080/auth/realms/master/protocol/cas'
 action_pattern='action="([^"]+)"'
 ticket_pattern='Location: .*\?ticket=(ST-[-A-Za-z0-9_.=]+)'
 
 get_ticket() {
-    login_response=$(curl --fail --silent -c /tmp/cookies http://localhost:8080/auth/realms/master/protocol/cas/login?service=http://localhost)
-    if [[ !($login_response =~ $action_pattern) ]] ; then
+    local cookie_options="-b /tmp/cookies"
+    if [ "$1" == "save_cookies" ]; then
+      cookie_options="${cookie_options} -c /tmp/cookies"
+    fi
+
+    local login_response=$(curl --fail --silent -c /tmp/cookies "${keycloak_cas_url}/login?service=http://localhost")
+    if [[ ! ($login_response =~ $action_pattern) ]] ; then
         echo "Could not parse login form in response"
-        echo $login_response
+        echo "${login_response}"
         exit 1
     fi
 
-    login_url=${BASH_REMATCH[1]//&amp;/&}
-    redirect_response=$(curl --fail --silent -D - -b /tmp/cookies --data 'username=admin&password=admin' "$login_url")
-    if [[ !($redirect_response =~ $ticket_pattern) ]] ; then
+    local login_url=${BASH_REMATCH[1]//&amp;/&}
+    local redirect_response=$(curl --fail --silent -D - $cookie_options --data 'username=admin&password=admin' "$login_url")
+    if [[ ! ($redirect_response =~ $ticket_pattern) ]] ; then
         echo "No service ticket found in response"
-        echo $redirect_response
+        echo "${redirect_response}"
         exit 1
     fi
 
-    ticket=${BASH_REMATCH[1]}
-    echo $ticket
+    echo "${BASH_REMATCH[1]}"
 }
 
-get_ticket
-curl --fail --silent "http://localhost:8080/auth/realms/master/protocol/cas/validate?service=http://localhost&ticket=$ticket"
+# CAS 1.0
+ticket=$(get_ticket)
+curl --fail --silent "${keycloak_cas_url}/validate?service=http://localhost&ticket=$ticket"
 echo
 
-get_ticket
-curl --fail --silent "http://localhost:8080/auth/realms/master/protocol/cas/serviceValidate?service=http://localhost&format=XML&ticket=$ticket"
+# CAS 2.0
+ticket=$(get_ticket)
+curl --fail --silent "${keycloak_cas_url}/serviceValidate?service=http://localhost&format=XML&ticket=$ticket"
 echo
 
-get_ticket
-curl --fail --silent "http://localhost:8080/auth/realms/master/protocol/cas/serviceValidate?service=http://localhost&format=JSON&ticket=$ticket"
+ticket=$(get_ticket)
+curl --fail --silent "${keycloak_cas_url}/serviceValidate?service=http://localhost&format=JSON&ticket=$ticket"
 echo
 
-get_ticket
-curl --fail --silent "http://localhost:8080/auth/realms/master/protocol/cas/p3/serviceValidate?service=http://localhost&format=JSON&ticket=$ticket"
+# CAS 3.0
+ticket=$(get_ticket save_cookies)
+curl --fail --silent "${keycloak_cas_url}/p3/serviceValidate?service=http://localhost&format=JSON&ticket=$ticket"
 echo
+
+# CAS, gateway option
+get_ticket save_cookies
+login_response=$(curl --fail --silent -D - -b /tmp/cookies "${keycloak_cas_url}/login?service=http://localhost&gateway=true")
+if echo "${login_response}" | grep '^Location: http://localhost\?ticket='; then
+    echo "Gateway option did not redirect back to service with ticket"
+    echo "${login_response}"
+    exit 1
+fi
+
+login_response=$(curl --fail --silent -D - "${keycloak_cas_url}/login?service=http://localhost&gateway=true")
+if echo "${login_response}" | grep '^Location: http://localhost$'; then
+    echo "Gateway option did not redirect back to service without ticket"
+    echo "${login_response}"
+    exit 1
+fi

--- a/src/main/java/org/keycloak/protocol/cas/endpoints/AuthorizationEndpoint.java
+++ b/src/main/java/org/keycloak/protocol/cas/endpoints/AuthorizationEndpoint.java
@@ -51,6 +51,9 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         if (renew) {
             authenticationSession.setClientNote(CASLoginProtocol.RENEW_PARAM, "true");
         }
+        if (gateway) {
+            authenticationSession.setClientNote(CASLoginProtocol.GATEWAY_PARAM, "true");
+        }
 
         this.event.event(EventType.LOGIN);
         return handleBrowserAuthenticationRequest(authenticationSession, new CASLoginProtocol(session, realm, session.getContext().getUri(), headers, event), gateway, false);


### PR DESCRIPTION
Per specification if gateway option is set and no authorization data is present, then user should be redirected back to the service.

This module responded with 500 Internal Server Error instead.