### PR TITLE
Fix SAML 1.1 Authentication

### DIFF
--- a/integrationTest/samlValidateTemplate.xml
+++ b/integrationTest/samlValidateTemplate.xml
@@ -1,0 +1,8 @@
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Header/>
+    <SOAP-ENV:Body>
+        <samlp:Request xmlns:samlp="urn:oasis:names:tc:SAML:1.0:protocol" MajorVersion="1" MinorVersion="1" RequestID="_example_request" IssueInstant="TIMESTAMP">
+            <samlp:AssertionArtifact>CAS_TICKET</samlp:AssertionArtifact>
+        </samlp:Request>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/integrationTest/suite.sh
+++ b/integrationTest/suite.sh
@@ -3,15 +3,20 @@ set -e
 
 keycloak_cas_url='http://localhost:8080/realms/master/protocol/cas'
 action_pattern='action="([^"]+)"'
-ticket_pattern='Location: .*\?ticket=(ST-[-A-Za-z0-9_.=]+)'
 
 get_ticket() {
     local cookie_options="-b /tmp/cookies"
+    local ticket_pattern='Location: .*\?ticket=(ST-[-A-Za-z0-9_.=]+)'
+    local client_url_param=service
+
     if [ "$1" == "save_cookies" ]; then
       cookie_options="${cookie_options} -c /tmp/cookies"
+    elif [ "$1" == "SAML" ]; then
+      ticket_pattern='Location: .*\?SAMLart=(ST-[-A-Za-z0-9_.=]+)'
+      client_url_param=TARGET
     fi
 
-    local login_response=$(curl --fail --silent -c /tmp/cookies "${keycloak_cas_url}/login?service=http://localhost")
+    local login_response=$(curl --fail --silent -c /tmp/cookies "${keycloak_cas_url}/login?${client_url_param}=http://localhost")
     if [[ ! ($login_response =~ $action_pattern) ]] ; then
         echo "Could not parse login form in response"
         echo "${login_response}"
@@ -46,6 +51,16 @@ echo
 # CAS 3.0
 ticket=$(get_ticket save_cookies)
 curl --fail --silent "${keycloak_cas_url}/p3/serviceValidate?service=http://localhost&format=JSON&ticket=$ticket"
+echo
+
+# SAML 1.1
+ticket=$(get_ticket SAML)
+timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+saml_template=$(dirname "$0")/samlValidateTemplate.xml
+sed -e "s/CAS_TICKET/$ticket/g" -e "s/TIMESTAMP/$timestamp/g" "$saml_template" \
+  | curl --fail --silent -X POST -H "Content-Type: text/xml" \
+      -H "SOAPAction: http://www.oasis-open.org/committees/security" \
+      --data-binary @- "${keycloak_cas_url}/samlValidate?TARGET=http://localhost"
 echo
 
 # CAS, gateway option

--- a/src/main/java/org/keycloak/protocol/cas/CASLoginProtocol.java
+++ b/src/main/java/org/keycloak/protocol/cas/CASLoginProtocol.java
@@ -36,6 +36,7 @@ public class CASLoginProtocol implements LoginProtocol {
     public static final String FORMAT_PARAM = "format";
 
     public static final String TICKET_RESPONSE_PARAM = "ticket";
+    public static final String SAMLART_RESPONSE_PARAM = "SAMLart";
 
     public static final String SERVICE_TICKET_PREFIX = "ST-";
     public static final String SESSION_SERVICE_TICKET = "service_ticket";
@@ -102,7 +103,15 @@ public class CASLoginProtocol implements LoginProtocol {
         String code = OAuth2CodeParser.persistCode(session, clientSession, codeData);
 
         KeycloakUriBuilder uriBuilder = KeycloakUriBuilder.fromUri(service);
-        uriBuilder.queryParam(TICKET_RESPONSE_PARAM, SERVICE_TICKET_PREFIX + code);
+
+        String loginTicket = SERVICE_TICKET_PREFIX + code;
+
+        if (authSession.getClientNotes().containsKey(CASLoginProtocol.TARGET_PARAM)) {
+            // This was a SAML 1.1 auth request so return the ticket ID as "SAMLart" instead of "ticket"
+            uriBuilder.queryParam(SAMLART_RESPONSE_PARAM, loginTicket);
+        } else {
+            uriBuilder.queryParam(TICKET_RESPONSE_PARAM, loginTicket);
+        }
 
         URI redirectUri = uriBuilder.build();
 

--- a/src/main/java/org/keycloak/protocol/cas/endpoints/SamlValidateEndpoint.java
+++ b/src/main/java/org/keycloak/protocol/cas/endpoints/SamlValidateEndpoint.java
@@ -36,9 +36,9 @@ public class SamlValidateEndpoint extends AbstractValidateEndpoint {
     @Consumes("text/xml;charset=utf-8")
     @Produces("text/xml;charset=utf-8")
     public Response validate(String input) {
-        MultivaluedMap<String, String> queryParams = request.getUri().getQueryParameters();
+        MultivaluedMap<String, String> queryParams = session.getContext().getUri().getQueryParameters();
         try {
-            String soapAction = Optional.ofNullable(request.getHttpHeaders().getHeaderString("SOAPAction")).map(s -> s.trim().replace("\"", "")).orElse("");
+            String soapAction = Optional.ofNullable(session.getContext().getRequestHeaders().getHeaderString("SOAPAction")).map(s -> s.trim().replace("\"", "")).orElse("");
             if (!soapAction.equals("http://www.oasis-open.org/committees/security")) {
                 throw new CASValidationException(CASErrorCode.INTERNAL_ERROR, "Not a validation request", Response.Status.BAD_REQUEST);
             }
@@ -49,7 +49,7 @@ public class SamlValidateEndpoint extends AbstractValidateEndpoint {
             checkRealm();
             checkSsl();
             checkClient(service);
-            String issuer = Urls.realmIssuer(request.getUri().getBaseUri(), realm.getName());
+            String issuer = Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName());
             String ticket = getTicket(input);
 
             checkTicket(ticket, renew);


### PR DESCRIPTION
This merge request should resolve the following:

1. samlValidate throws a "NoSuchMethodError" exception.
    - `2022-03-25 14:08:39,383 ERROR [org.keycloak.services.error.KeycloakErrorHandler] (executor-thread-38) Uncaught server error: java.lang.NoSuchMethodError: 'org.jboss.resteasy.spi.ResteasyUriInfo org.jboss.resteasy.spi.HttpRequest.getUri()'`
    - I think this was due to the change to the Quarkus runtime for Keycloak 17.0
1. SAML 1.1 specifies that the service provides a TARGET parameter to the login endpoint and the identity provider should redirect the user back to the service with a SAMLart parameter.
    - The official Java CAS client uses these parameters for SAML 1.1 authentication. [See here.](https://github.com/apereo/java-cas-client/blob/v3.3.0/cas-client-core/src/main/java/org/jasig/cas/client/authentication/Saml11AuthenticationFilter.java#L41)
    - Also documented in the SAML 1.1 Bindings specification. See section 4.1.1.3 and 4.1.1.4 in the [specifications](https://www.oasis-open.org/committees/download.php/3405/oasis-sstc-saml-bindings-1.1.pdf).
    - This change is fully backwards compatible with any existing clients since "TARGET" is currently not supported in the /login endpoint anyway. It only affects requests that specify a TARGET parameter to the login endpoint. 
1. Adds a SAML 1.1 check in the suite.sh integration test. 

Each of these changes are in their own commit. Please let me know if there are any changes you would like to see. 

Thank you for the plugin!