### PR TITLE
validate endpoint should also return username

### DIFF
--- a/src/main/java/org/keycloak/protocol/cas/endpoints/ValidateEndpoint.java
+++ b/src/main/java/org/keycloak/protocol/cas/endpoints/ValidateEndpoint.java
@@ -46,7 +46,10 @@ public class ValidateEndpoint extends AbstractValidateEndpoint {
     }
 
     protected Response successResponse() {
-        return Response.ok(RESPONSE_OK).type(MediaType.TEXT_PLAIN).build();
+        StringBuilder sb = new StringBuilder(RESPONSE_OK);
+        sb.append(clientSession.getUserSession().getUser().getUsername());
+        sb.append("\n");
+        return Response.ok(sb.toString()).type(MediaType.TEXT_PLAIN).build();
     }
 
     protected Response errorResponse(CASValidationException e) {


### PR DESCRIPTION
The /validate endpoint currently only returns `"yes\n"` on success. 
The CAS java client expects the username to be listed on it's own line as well. 

See the [CAS10TicketValidator](https://github.com/apereo/java-cas-client/blob/v3.3.0/cas-client-core/src/main/java/org/jasig/cas/client/validation/Cas10TicketValidator.java#L50) and the [CAS Protocol Specifications](https://github.com/apereo/cas/blob/v6.5.1/docs/cas-server-documentation/protocol/CAS-Protocol-Specification.md#242-response)