### PR TITLE
CAS Username Mapper

### DIFF
--- a/src/main/java/org/keycloak/protocol/cas/CASLoginProtocol.java
+++ b/src/main/java/org/keycloak/protocol/cas/CASLoginProtocol.java
@@ -10,6 +10,7 @@ import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.models.*;
 import org.keycloak.protocol.LoginProtocol;
 import org.keycloak.protocol.cas.utils.LogoutHelper;
+import org.keycloak.protocol.cas.utils.UsernameMapperHelper;
 import org.keycloak.protocol.oidc.utils.OAuth2Code;
 import org.keycloak.protocol.oidc.utils.OAuth2CodeParser;
 import org.keycloak.services.ErrorPage;
@@ -92,6 +93,11 @@ public class CASLoginProtocol implements LoginProtocol {
     @Override
     public Response authenticated(AuthenticationSessionModel authSession, UserSessionModel userSession, ClientSessionContext clientSessionCtx) {
         AuthenticatedClientSessionModel clientSession = clientSessionCtx.getClientSession();
+
+        // Verify that if a username mapper is set - there is a username being returned
+        if(UsernameMapperHelper.getMappedUsername(session, clientSession) == null) {
+            return ErrorPage.error(session, authSession, Response.Status.INTERNAL_SERVER_ERROR, "Unable to map username for CAS client");
+        }
 
         String service = authSession.getRedirectUri();
         //TODO validate service

--- a/src/main/java/org/keycloak/protocol/cas/endpoints/SamlValidateEndpoint.java
+++ b/src/main/java/org/keycloak/protocol/cas/endpoints/SamlValidateEndpoint.java
@@ -9,6 +9,7 @@ import org.keycloak.protocol.cas.CASLoginProtocol;
 import org.keycloak.protocol.cas.representations.CASErrorCode;
 import org.keycloak.protocol.cas.representations.SamlResponseHelper;
 import org.keycloak.protocol.cas.utils.CASValidationException;
+import org.keycloak.protocol.cas.utils.UsernameMapperHelper;
 import org.keycloak.services.Urls;
 import org.xml.sax.InputSource;
 
@@ -57,7 +58,7 @@ public class SamlValidateEndpoint extends AbstractValidateEndpoint {
 
             Map<String, Object> attributes = getUserAttributes();
 
-            SAML11ResponseType response = SamlResponseHelper.successResponse(issuer, user.getUsername(), attributes);
+            SAML11ResponseType response = SamlResponseHelper.successResponse(issuer, UsernameMapperHelper.getMappedUsername(session,clientSession), attributes);
 
             return Response.ok(SamlResponseHelper.soap(response)).build();
 

--- a/src/main/java/org/keycloak/protocol/cas/endpoints/ServiceValidateEndpoint.java
+++ b/src/main/java/org/keycloak/protocol/cas/endpoints/ServiceValidateEndpoint.java
@@ -8,6 +8,7 @@ import org.keycloak.protocol.cas.representations.CASServiceResponse;
 import org.keycloak.protocol.cas.utils.CASValidationException;
 import org.keycloak.protocol.cas.utils.ContentTypeHelper;
 import org.keycloak.protocol.cas.utils.ServiceResponseHelper;
+import org.keycloak.protocol.cas.utils.UsernameMapperHelper;
 import org.keycloak.services.managers.ClientSessionCode;
 import org.keycloak.services.util.DefaultClientSessionContext;
 
@@ -28,7 +29,7 @@ public class ServiceValidateEndpoint extends ValidateEndpoint {
     protected Response successResponse() {
         UserSessionModel userSession = clientSession.getUserSession();
         Map<String, Object> attributes = getUserAttributes();
-        CASServiceResponse serviceResponse = ServiceResponseHelper.createSuccess(userSession.getUser().getUsername(), attributes);
+        CASServiceResponse serviceResponse = ServiceResponseHelper.createSuccess(UsernameMapperHelper.getMappedUsername(session,clientSession), attributes);
         return prepare(Response.Status.OK, serviceResponse);
     }
 

--- a/src/main/java/org/keycloak/protocol/cas/mappers/AbstractCASProtocolMapper.java
+++ b/src/main/java/org/keycloak/protocol/cas/mappers/AbstractCASProtocolMapper.java
@@ -3,16 +3,10 @@ package org.keycloak.protocol.cas.mappers;
 import org.keycloak.Config;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
-import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.protocol.ProtocolMapper;
 import org.keycloak.protocol.cas.CASLoginProtocol;
-import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
 
-import java.util.Map;
-
-public abstract class AbstractCASProtocolMapper implements ProtocolMapper, CASAttributeMapper {
-    public static final String TOKEN_MAPPER_CATEGORY = "Token mapper";
-
+public abstract class AbstractCASProtocolMapper implements ProtocolMapper {
     @Override
     public String getProtocol() {
         return CASLoginProtocol.LOGIN_PROTOCOL;
@@ -33,22 +27,5 @@ public abstract class AbstractCASProtocolMapper implements ProtocolMapper, CASAt
 
     @Override
     public void postInit(KeycloakSessionFactory factory) {
-    }
-
-    @Override
-    public String getDisplayCategory() {
-        return TOKEN_MAPPER_CATEGORY;
-    }
-
-    protected void setMappedAttribute(Map<String, Object> attributes, ProtocolMapperModel mappingModel, Object attributeValue) {
-        setPlainAttribute(attributes, mappingModel, OIDCAttributeMapperHelper.mapAttributeValue(mappingModel, attributeValue));
-    }
-
-    protected void setPlainAttribute(Map<String, Object> attributes, ProtocolMapperModel mappingModel, Object attributeValue) {
-        String protocolClaim = mappingModel.getConfig().get(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME);
-        if (protocolClaim == null || attributeValue == null) {
-            return;
-        }
-        attributes.put(protocolClaim, attributeValue);
     }
 }

--- a/src/main/java/org/keycloak/protocol/cas/mappers/AbstractUserAttributeMapper.java
+++ b/src/main/java/org/keycloak/protocol/cas/mappers/AbstractUserAttributeMapper.java
@@ -1,0 +1,27 @@
+package org.keycloak.protocol.cas.mappers;
+
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
+
+import java.util.Map;
+
+public abstract class AbstractUserAttributeMapper extends AbstractCASProtocolMapper implements CASAttributeMapper {
+    public static final String TOKEN_MAPPER_CATEGORY = "Token mapper";
+
+    @Override
+    public String getDisplayCategory() {
+        return TOKEN_MAPPER_CATEGORY;
+    }
+
+    protected void setMappedAttribute(Map<String, Object> attributes, ProtocolMapperModel mappingModel, Object attributeValue) {
+        setPlainAttribute(attributes, mappingModel, OIDCAttributeMapperHelper.mapAttributeValue(mappingModel, attributeValue));
+    }
+
+    protected void setPlainAttribute(Map<String, Object> attributes, ProtocolMapperModel mappingModel, Object attributeValue) {
+        String protocolClaim = mappingModel.getConfig().get(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME);
+        if (protocolClaim == null || attributeValue == null) {
+            return;
+        }
+        attributes.put(protocolClaim, attributeValue);
+    }
+}

--- a/src/main/java/org/keycloak/protocol/cas/mappers/AbstractUserRoleMappingMapper.java
+++ b/src/main/java/org/keycloak/protocol/cas/mappers/AbstractUserRoleMappingMapper.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
  *
  * @author <a href="mailto:thomas.darimont@gmail.com">Thomas Darimont</a>
  */
-abstract class AbstractUserRoleMappingMapper extends AbstractCASProtocolMapper {
+abstract class AbstractUserRoleMappingMapper extends AbstractUserAttributeMapper {
 
     /**
      * Retrieves all roles of the current user based on direct roles set to the user, its groups and their parent groups.

--- a/src/main/java/org/keycloak/protocol/cas/mappers/CASUsernameMapper.java
+++ b/src/main/java/org/keycloak/protocol/cas/mappers/CASUsernameMapper.java
@@ -1,0 +1,11 @@
+package org.keycloak.protocol.cas.mappers;
+
+import org.keycloak.models.*;
+import org.keycloak.protocol.ProtocolMapper;
+
+public interface CASUsernameMapper extends ProtocolMapper {
+
+    String getMappedUsername(ProtocolMapperModel mappingModel, KeycloakSession session,
+                             UserSessionModel userSession, AuthenticatedClientSessionModel clientSession);
+    
+}

--- a/src/main/java/org/keycloak/protocol/cas/mappers/FullNameMapper.java
+++ b/src/main/java/org/keycloak/protocol/cas/mappers/FullNameMapper.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class FullNameMapper extends AbstractCASProtocolMapper {
+public class FullNameMapper extends AbstractUserAttributeMapper {
     private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
 
     static {

--- a/src/main/java/org/keycloak/protocol/cas/mappers/GroupMembershipMapper.java
+++ b/src/main/java/org/keycloak/protocol/cas/mappers/GroupMembershipMapper.java
@@ -10,7 +10,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-public class GroupMembershipMapper extends AbstractCASProtocolMapper {
+public class GroupMembershipMapper extends AbstractUserAttributeMapper {
     private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
 
     private static final String FULL_PATH = "full.path";

--- a/src/main/java/org/keycloak/protocol/cas/mappers/HardcodedClaim.java
+++ b/src/main/java/org/keycloak/protocol/cas/mappers/HardcodedClaim.java
@@ -11,9 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME;
-
-public class HardcodedClaim extends AbstractCASProtocolMapper {
+public class HardcodedClaim extends AbstractUserAttributeMapper {
     private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
 
     public static final String CLAIM_VALUE = "claim.value";

--- a/src/main/java/org/keycloak/protocol/cas/mappers/UserAttributeCasUsernameMapper.java
+++ b/src/main/java/org/keycloak/protocol/cas/mappers/UserAttributeCasUsernameMapper.java
@@ -1,0 +1,77 @@
+package org.keycloak.protocol.cas.mappers;
+
+import org.keycloak.Config;
+import org.keycloak.models.*;
+import org.keycloak.protocol.ProtocolMapper;
+import org.keycloak.protocol.ProtocolMapperUtils;
+import org.keycloak.protocol.cas.CASLoginProtocol;
+import org.keycloak.provider.ProviderConfigProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class UserAttributeCasUsernameMapper extends AbstractCASProtocolMapper implements CASUsernameMapper {
+    public static final String PROVIDER_ID = "cas-usermodel-username-mapper";
+    public static final String USERNAME_MAPPER_CATEGORY = "CAS Username Mapper";
+    private static final String CONF_FALLBACK_TO_USERNAME_IF_NULL = "username_fallback";
+
+    private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
+    static {
+        ProviderConfigProperty property;
+        property = new ProviderConfigProperty();
+        property.setName(ProtocolMapperUtils.USER_ATTRIBUTE);
+        property.setLabel(ProtocolMapperUtils.USER_MODEL_PROPERTY_LABEL);
+        property.setType(ProviderConfigProperty.STRING_TYPE);
+        property.setHelpText(ProtocolMapperUtils.USER_MODEL_PROPERTY_HELP_TEXT);
+        configProperties.add(property);
+
+        property = new ProviderConfigProperty();
+        property.setName(CONF_FALLBACK_TO_USERNAME_IF_NULL);
+        property.setLabel("Use username if attribute is missing");
+        property.setHelpText("Should the User's username be used if the specified attribute is blank?");
+        property.setType(ProviderConfigProperty.BOOLEAN_TYPE);
+        property.setDefaultValue(false);
+        configProperties.add(property);
+
+
+    }
+
+    @Override
+    public final String getDisplayCategory() {
+        return USERNAME_MAPPER_CATEGORY;
+    }
+
+    @Override
+    public final String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "User Attribute Mapper For CAS Username";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Maps a user attribute to CAS Username value.";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return configProperties;
+    }
+
+    @Override
+    public String getMappedUsername(ProtocolMapperModel mappingModel, KeycloakSession session,
+                                    UserSessionModel userSession, AuthenticatedClientSessionModel clientSession) {
+
+        boolean defaultIfNull = Boolean.parseBoolean(mappingModel.getConfig().get(CONF_FALLBACK_TO_USERNAME_IF_NULL));
+        UserModel user = userSession.getUser();
+        String mappedUsername = user.getFirstAttribute(mappingModel.getConfig().get(ProtocolMapperUtils.USER_ATTRIBUTE));
+
+        if(mappedUsername == null && defaultIfNull) {
+            mappedUsername = user.getUsername();
+        }
+        return mappedUsername;
+    }
+}

--- a/src/main/java/org/keycloak/protocol/cas/mappers/UserAttributeMapper.java
+++ b/src/main/java/org/keycloak/protocol/cas/mappers/UserAttributeMapper.java
@@ -11,7 +11,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-public class UserAttributeMapper extends AbstractCASProtocolMapper {
+public class UserAttributeMapper extends AbstractUserAttributeMapper {
     private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
 
     static {

--- a/src/main/java/org/keycloak/protocol/cas/mappers/UserClientRoleMappingMapper.java
+++ b/src/main/java/org/keycloak/protocol/cas/mappers/UserClientRoleMappingMapper.java
@@ -51,11 +51,6 @@ public class UserClientRoleMappingMapper extends AbstractUserRoleMappingMapper {
     }
 
     @Override
-    public String getDisplayCategory() {
-        return TOKEN_MAPPER_CATEGORY;
-    }
-
-    @Override
     public String getHelpText() {
         return "Map a user client role to a token claim.";
     }

--- a/src/main/java/org/keycloak/protocol/cas/mappers/UserPropertyMapper.java
+++ b/src/main/java/org/keycloak/protocol/cas/mappers/UserPropertyMapper.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class UserPropertyMapper extends AbstractCASProtocolMapper {
+public class UserPropertyMapper extends AbstractUserAttributeMapper {
     private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
 
     static {

--- a/src/main/java/org/keycloak/protocol/cas/mappers/UserRealmRoleMappingMapper.java
+++ b/src/main/java/org/keycloak/protocol/cas/mappers/UserRealmRoleMappingMapper.java
@@ -46,10 +46,6 @@ public class UserRealmRoleMappingMapper extends AbstractUserRoleMappingMapper {
         return "User Realm Role";
     }
 
-    @Override
-    public String getDisplayCategory() {
-        return TOKEN_MAPPER_CATEGORY;
-    }
 
     @Override
     public String getHelpText() {

--- a/src/main/java/org/keycloak/protocol/cas/mappers/UserSessionNoteMapper.java
+++ b/src/main/java/org/keycloak/protocol/cas/mappers/UserSessionNoteMapper.java
@@ -12,7 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class UserSessionNoteMapper extends AbstractCASProtocolMapper {
+public class UserSessionNoteMapper extends AbstractUserAttributeMapper {
 
     private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
 

--- a/src/main/java/org/keycloak/protocol/cas/mappers/UserSessionNoteMapper.java
+++ b/src/main/java/org/keycloak/protocol/cas/mappers/UserSessionNoteMapper.java
@@ -45,10 +45,6 @@ public class UserSessionNoteMapper extends AbstractUserAttributeMapper {
         return "User Session Note";
     }
 
-    @Override
-    public String getDisplayCategory() {
-        return TOKEN_MAPPER_CATEGORY;
-    }
 
     @Override
     public String getHelpText() {

--- a/src/main/java/org/keycloak/protocol/cas/utils/UsernameMapperHelper.java
+++ b/src/main/java/org/keycloak/protocol/cas/utils/UsernameMapperHelper.java
@@ -1,0 +1,32 @@
+package org.keycloak.protocol.cas.utils;
+
+import org.keycloak.models.*;
+import org.keycloak.protocol.ProtocolMapper;
+import org.keycloak.protocol.ProtocolMapperUtils;
+import org.keycloak.protocol.cas.mappers.CASUsernameMapper;
+import org.keycloak.services.util.DefaultClientSessionContext;
+
+import java.util.Map;
+
+public class UsernameMapperHelper {
+    public static String getMappedUsername(KeycloakSession session, AuthenticatedClientSessionModel clientSession) {
+        // CAS protocol does not support scopes, so pass null scopeParam
+        ClientSessionContext clientSessionCtx = DefaultClientSessionContext.fromClientSessionAndScopeParameter(clientSession, null, session);
+        UserSessionModel userSession = clientSession.getUserSession();
+
+
+        Map.Entry<ProtocolMapperModel, ProtocolMapper> mapperPair = ProtocolMapperUtils.getSortedProtocolMappers(session,clientSessionCtx)
+                .filter(e -> e.getValue() instanceof CASUsernameMapper)
+                .findFirst()
+                .orElse(null);
+
+        String mappedUsername = userSession.getUser().getUsername();
+
+        if(mapperPair != null) {
+            ProtocolMapperModel mapping = mapperPair.getKey();
+            CASUsernameMapper casUsernameMapper = (CASUsernameMapper) mapperPair.getValue();
+            mappedUsername = casUsernameMapper.getMappedUsername(mapping, session, userSession, clientSession);
+        }
+        return mappedUsername;
+    }
+}

--- a/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
+++ b/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
@@ -23,3 +23,4 @@ org.keycloak.protocol.cas.mappers.UserClientRoleMappingMapper
 org.keycloak.protocol.cas.mappers.UserPropertyMapper
 org.keycloak.protocol.cas.mappers.UserRealmRoleMappingMapper
 org.keycloak.protocol.cas.mappers.UserSessionNoteMapper
+org.keycloak.protocol.cas.mappers.UserAttributeCasUsernameMapper


### PR DESCRIPTION
This Merge request adds a new protocol mapper to allow the username that the CAS protocol returns to the service be derived from one of the user's attributes. 

This is useful for services that for example expect a user's email to be returned by CAS instead of the username. At my organization we have several vendor products that requires CAS to provide a GUID attribute instead of a username. 

This functionality is supported by the [Apereo CAS server](https://apereo.github.io/cas/6.5.x/integration/Attribute-Release-PrincipalId.html) and the [Shibboleth server's CAS module](https://shibboleth.atlassian.net/wiki/spaces/IDP4/pages/1265631627/CasProtocolConfiguration#Configure-Proxy-Trust-(Optional)) implementations of the CAS protocol. 

Implementing this functionality will allow a migration path from those severs. 

The mapper has an option to default to the username if the required attribute is missing. 

I know this is a rather large change but I am more than happy to accommodate any changes you'd like to see.

Thanks Again!