### PR TITLE
Update to Keycloak 20.0.0 (with fixes for non-Stream API deprecations)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.keycloak</groupId>
     <artifactId>keycloak-protocol-cas</artifactId>
-    <version>19.0.3</version>
+    <version>20.0.0</version>
     <name>Keycloak CAS Protocol</name>
     <description />
 

--- a/src/main/java/org/keycloak/protocol/cas/endpoints/AbstractValidateEndpoint.java
+++ b/src/main/java/org/keycloak/protocol/cas/endpoints/AbstractValidateEndpoint.java
@@ -22,6 +22,7 @@ import javax.ws.rs.core.Response;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public abstract class AbstractValidateEndpoint {
     protected final Logger logger = Logger.getLogger(getClass());
@@ -61,7 +62,7 @@ public abstract class AbstractValidateEndpoint {
             throw new CASValidationException(CASErrorCode.INVALID_REQUEST, "Missing parameter: " + CASLoginProtocol.SERVICE_PARAM, Response.Status.BAD_REQUEST);
         }
 
-        client = realm.getClients().stream()
+        client = realm.getClientsStream()
                 .filter(c -> CASLoginProtocol.LOGIN_PROTOCOL.equals(c.getProtocol()))
                 .filter(c -> RedirectUtils.verifyRedirectUri(session, service, c) != null)
                 .findFirst().orElse(null);
@@ -155,7 +156,7 @@ public abstract class AbstractValidateEndpoint {
         // CAS protocol does not support scopes, so pass null scopeParam
         ClientSessionContext clientSessionCtx = DefaultClientSessionContext.fromClientSessionAndScopeParameter(clientSession, null, session);
 
-        Set<ProtocolMapperModel> mappings = clientSessionCtx.getProtocolMappers();
+        Set<ProtocolMapperModel> mappings = clientSessionCtx.getProtocolMappersStream().collect(Collectors.toSet());
         KeycloakSessionFactory sessionFactory = session.getKeycloakSessionFactory();
         Map<String, Object> attributes = new HashMap<>();
         for (ProtocolMapperModel mapping : mappings) {

--- a/src/main/java/org/keycloak/protocol/cas/endpoints/AuthorizationEndpoint.java
+++ b/src/main/java/org/keycloak/protocol/cas/endpoints/AuthorizationEndpoint.java
@@ -76,7 +76,7 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
             throw new ErrorPageException(session, Response.Status.BAD_REQUEST, Messages.MISSING_PARAMETER, CASLoginProtocol.SERVICE_PARAM);
         }
 
-        client = realm.getClients().stream()
+        client = realm.getClientsStream()
                 .filter(c -> CASLoginProtocol.LOGIN_PROTOCOL.equals(c.getProtocol()))
                 .filter(c -> RedirectUtils.verifyRedirectUri(session, service, c) != null)
                 .findFirst().orElse(null);

--- a/src/main/java/org/keycloak/protocol/cas/endpoints/LogoutEndpoint.java
+++ b/src/main/java/org/keycloak/protocol/cas/endpoints/LogoutEndpoint.java
@@ -70,7 +70,7 @@ public class LogoutEndpoint {
             return;
         }
 
-        client = realm.getClients().stream()
+        client = realm.getClientsStream()
                 .filter(c -> CASLoginProtocol.LOGIN_PROTOCOL.equals(c.getProtocol()))
                 .filter(c -> RedirectUtils.verifyRedirectUri(session, service, c) != null)
                 .findFirst().orElse(null);

--- a/src/main/java/org/keycloak/protocol/cas/mappers/GroupMembershipMapper.java
+++ b/src/main/java/org/keycloak/protocol/cas/mappers/GroupMembershipMapper.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class GroupMembershipMapper extends AbstractCASProtocolMapper {
     private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
@@ -54,7 +55,7 @@ public class GroupMembershipMapper extends AbstractCASProtocolMapper {
                              KeycloakSession session, ClientSessionContext clientSessionCt) {
         List<String> membership = new LinkedList<>();
         boolean fullPath = useFullPath(mappingModel);
-        for (GroupModel group : userSession.getUser().getGroups()) {
+        for (GroupModel group : userSession.getUser().getGroupsStream().collect(Collectors.toSet())) {
             if (fullPath) {
                 membership.add(ModelToRepresentation.buildGroupPath(group));
             } else {


### PR DESCRIPTION
Keycloak 20.0.0 removed some (long) deprecated non-Stream API methods to access realm and user data - this pull request replaces them with their Stream API counterparts.