### PR TITLE
GitHub Actions workflow updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
       - id: java
         name: Install Java and Maven
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: zulu
           java-version: 11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,14 +24,14 @@ jobs:
       - id: vars
         name: Get project variables
         run: |
-          echo -n "::set-output name=keycloakVersion::"
-          mvn -q help:evaluate -Dexpression=keycloak.version -DforceStdout 2> /dev/null | grep -E '^[0-9a-zA-Z.-]+$'
-          echo -n "::set-output name=artifactId::"
-          mvn -q help:evaluate -Dexpression=project.artifactId -DforceStdout 2> /dev/null | grep -E '^[0-9a-zA-Z.-]+$'
-          echo -n "::set-output name=projectName::"
-          mvn -q help:evaluate -Dexpression=project.name -DforceStdout 2> /dev/null | grep -E '^[0-9a-zA-Z :,.-]+$'
-          echo -n "::set-output name=projectVersion::"
-          mvn -q help:evaluate -Dexpression=project.version -DforceStdout 2> /dev/null | grep -E '^[0-9a-zA-Z.-]+$'
+          echo -n "keycloakVersion=" >> $GITHUB_OUTPUT
+          mvn -q help:evaluate -Dexpression=keycloak.version -DforceStdout 2> /dev/null | grep -E '^[0-9a-zA-Z.-]+$' >> $GITHUB_OUTPUT
+          echo -n "artifactId=" >> $GITHUB_OUTPUT
+          mvn -q help:evaluate -Dexpression=project.artifactId -DforceStdout 2> /dev/null | grep -E '^[0-9a-zA-Z.-]+$' >> $GITHUB_OUTPUT
+          echo -n "projectName=" >> $GITHUB_OUTPUT
+          mvn -q help:evaluate -Dexpression=project.name -DforceStdout 2> /dev/null | grep -E '^[0-9a-zA-Z :,.-]+$' >> $GITHUB_OUTPUT
+          echo -n "projectVersion=" >> $GITHUB_OUTPUT
+          mvn -q help:evaluate -Dexpression=project.version -DforceStdout 2> /dev/null | grep -E '^[0-9a-zA-Z.-]+$' >> $GITHUB_OUTPUT
 
       - name: Build project
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - id: download_artifact
         name: Download artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
       - id: java
         name: Install Java and Maven
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: zulu
           java-version: 11

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - id: download_artifact
         name: Download artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,14 +22,14 @@ jobs:
       - id: vars
         name: Get project variables
         run: |
-          echo -n "::set-output name=keycloakVersion::"
-          mvn -q help:evaluate -Dexpression=keycloak.version -DforceStdout 2> /dev/null | grep -E '^[0-9a-zA-Z.-]+$'
-          echo -n "::set-output name=artifactId::"
-          mvn -q help:evaluate -Dexpression=project.artifactId -DforceStdout 2> /dev/null | grep -E '^[0-9a-zA-Z.-]+$'
-          echo -n "::set-output name=projectName::"
-          mvn -q help:evaluate -Dexpression=project.name -DforceStdout 2> /dev/null | grep -E '^[0-9a-zA-Z :,.-]+$'
-          echo -n "::set-output name=projectVersion::"
-          mvn -q help:evaluate -Dexpression=project.version -DforceStdout 2> /dev/null | grep -E '^[0-9a-zA-Z.-]+$'
+          echo -n "keycloakVersion=" >> $GITHUB_OUTPUT
+          mvn -q help:evaluate -Dexpression=keycloak.version -DforceStdout 2> /dev/null | grep -E '^[0-9a-zA-Z.-]+$' >> $GITHUB_OUTPUT
+          echo -n "artifactId=" >> $GITHUB_OUTPUT
+          mvn -q help:evaluate -Dexpression=project.artifactId -DforceStdout 2> /dev/null | grep -E '^[0-9a-zA-Z.-]+$' >> $GITHUB_OUTPUT
+          echo -n "projectName=" >> $GITHUB_OUTPUT
+          mvn -q help:evaluate -Dexpression=project.name -DforceStdout 2> /dev/null | grep -E '^[0-9a-zA-Z :,.-]+$' >> $GITHUB_OUTPUT
+          echo -n "projectVersion=" >> $GITHUB_OUTPUT
+          mvn -q help:evaluate -Dexpression=project.version -DforceStdout 2> /dev/null | grep -E '^[0-9a-zA-Z.-]+$' >> $GITHUB_OUTPUT
 
       - name: Build project
         run: |

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -16,7 +16,7 @@ jobs:
 
       - id: java
         name: Install Java and Maven
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: zulu
           java-version: 11

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -29,20 +29,23 @@ jobs:
       - id: vars
         name: Get project variables
         run: |
-          echo -n "::set-output name=versionUpdated::"
-          [ -f pom.xml.versionsBackup ] && echo 1 || echo 0
-          echo -n "::set-output name=keycloakVersion::"
-          mvn -q help:evaluate -Dexpression=keycloak.version -DforceStdout 2> /dev/null | grep -E '^[0-9a-zA-Z.-]+$'
+          if [ -f pom.xml.versionsBackup ]; then
+            echo "versionUpdated=1"
+          else
+            echo "versionUpdated=0"
+          fi >> $GITHUB_OUTPUT
+          echo -n "keycloakVersion=" >> $GITHUB_OUTPUT
+          mvn -q help:evaluate -Dexpression=keycloak.version -DforceStdout 2> /dev/null | grep -E '^[0-9a-zA-Z.-]+$' >> $GITHUB_OUTPUT
 
       - id: check_branch
         name: Check if branch exists
         run: |
-          echo -n "::set-output name=commit::"
+          echo -n "commit=" >> $GITHUB_OUTPUT
           if [ '${{ steps.vars.outputs.versionUpdated }}' == '1' ]; then
             git ls-remote origin 'feature/keycloak-update-${{ steps.vars.outputs.keycloakVersion }}'
           else
             git rev-parse HEAD
-          fi
+          fi >> $GITHUB_OUTPUT
 
       - id: reset_repo
         name: Reset repository


### PR DESCRIPTION
Replace deprecated actions and commands:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ (affects `actions/setup-java@v2`)
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ (affects `::set-output`)