### PR TITLE
Proxy ticket service and proxy ticket validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ The following CAS features are currently implemented:
 
 The following features are **missing**:
 * SAML request/response [CAS 3.0 - optional]
-* Proxy ticket service and proxy ticket validation [CAS 2.0]
 
 The following features are out of scope:
 * Long-Term Tickets - Remember-Me [CAS 3.0 - optional]

--- a/src/main/java/org/keycloak/protocol/cas/CASLoginProtocol.java
+++ b/src/main/java/org/keycloak/protocol/cas/CASLoginProtocol.java
@@ -6,23 +6,20 @@ import jakarta.ws.rs.core.UriInfo;
 import org.apache.http.HttpEntity;
 import org.jboss.logging.Logger;
 import org.keycloak.common.util.KeycloakUriBuilder;
-import org.keycloak.common.util.Time;
 import org.keycloak.events.Details;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.events.EventType;
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.models.*;
 import org.keycloak.protocol.LoginProtocol;
+import org.keycloak.protocol.cas.endpoints.AbstractValidateEndpoint;
 import org.keycloak.protocol.cas.utils.LogoutHelper;
-import org.keycloak.protocol.oidc.utils.OAuth2Code;
-import org.keycloak.protocol.oidc.utils.OAuth2CodeParser;
 import org.keycloak.services.ErrorPage;
 import org.keycloak.services.managers.ResourceAdminManager;
 import org.keycloak.sessions.AuthenticationSessionModel;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.UUID;
 
 public class CASLoginProtocol implements LoginProtocol {
     private static final Logger logger = Logger.getLogger(CASLoginProtocol.class);
@@ -35,11 +32,17 @@ public class CASLoginProtocol implements LoginProtocol {
     public static final String GATEWAY_PARAM = "gateway";
     public static final String TICKET_PARAM = "ticket";
     public static final String FORMAT_PARAM = "format";
+    public static final String PGTURL_PARAM = "pgtUrl";
+    public static final String TARGET_SERVICE_PARAM = "targetService";
+    public static final String PGT_PARAM = "pgt";
 
     public static final String TICKET_RESPONSE_PARAM = "ticket";
     public static final String SAMLART_RESPONSE_PARAM = "SAMLart";
 
     public static final String SERVICE_TICKET_PREFIX = "ST-";
+    public static final String PROXY_GRANTING_TICKET_IOU_PREFIX = "PGTIOU-";
+    public static final String PROXY_GRANTING_TICKET_PREFIX = "PGT-";
+    public static final String PROXY_TICKET_PREFIX = "PT-";
     public static final String SESSION_SERVICE_TICKET = "service_ticket";
 
     public static final String LOGOUT_REDIRECT_URI = "CAS_LOGOUT_REDIRECT_URI";
@@ -98,15 +101,9 @@ public class CASLoginProtocol implements LoginProtocol {
         String service = authSession.getRedirectUri();
         //TODO validate service
 
-        OAuth2Code codeData = new OAuth2Code(UUID.randomUUID().toString(),
-                Time.currentTime() + userSession.getRealm().getAccessCodeLifespan(),
-                null, null, authSession.getRedirectUri(), null, null,
-                userSession.getId());
-        String code = OAuth2CodeParser.persistCode(session, clientSession, codeData);
-
         KeycloakUriBuilder uriBuilder = KeycloakUriBuilder.fromUri(service);
 
-        String loginTicket = SERVICE_TICKET_PREFIX + code;
+        String loginTicket = AbstractValidateEndpoint.getST(session, clientSession, service);
 
         if (authSession.getClientNotes().containsKey(CASLoginProtocol.TARGET_PARAM)) {
             // This was a SAML 1.1 auth request so return the ticket ID as "SAMLart" instead of "ticket"

--- a/src/main/java/org/keycloak/protocol/cas/CASLoginProtocolService.java
+++ b/src/main/java/org/keycloak/protocol/cas/CASLoginProtocolService.java
@@ -1,8 +1,8 @@
 package org.keycloak.protocol.cas;
 
 import jakarta.ws.rs.Path;
-import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
+
 import org.keycloak.events.EventBuilder;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -51,13 +51,12 @@ public class CASLoginProtocolService {
 
     @Path("proxyValidate")
     public Object proxyValidate() {
-        //TODO implement
-        return serviceValidate();
+        return new ProxyValidateEndpoint(session, realm, event);
     }
 
     @Path("proxy")
     public Object proxy() {
-        return Response.serverError().entity("Not implemented").build();
+        return new ProxyEndpoint(session, realm, event);
     }
 
     @Path("p3/serviceValidate")

--- a/src/main/java/org/keycloak/protocol/cas/endpoints/ProxyEndpoint.java
+++ b/src/main/java/org/keycloak/protocol/cas/endpoints/ProxyEndpoint.java
@@ -1,0 +1,57 @@
+package org.keycloak.protocol.cas.endpoints;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import org.jboss.resteasy.annotations.cache.NoCache;
+import org.keycloak.events.EventBuilder;
+import org.keycloak.events.EventType;
+import org.keycloak.models.*;
+import org.keycloak.protocol.cas.CASLoginProtocol;
+import org.keycloak.protocol.cas.representations.CASServiceResponse;
+import org.keycloak.protocol.cas.utils.CASValidationException;
+import org.keycloak.protocol.cas.utils.ContentTypeHelper;
+import org.keycloak.protocol.cas.utils.ServiceResponseHelper;
+
+public class ProxyEndpoint extends AbstractValidateEndpoint {
+
+    public ProxyEndpoint(KeycloakSession session, RealmModel realm, EventBuilder event) {
+        super(session, realm, event);
+    }
+
+    @GET
+    @NoCache
+    public Response build() {
+        MultivaluedMap<String, String> params = session.getContext().getUri().getQueryParameters();
+        String targetService = params.getFirst(CASLoginProtocol.TARGET_SERVICE_PARAM);
+        String pgt = params.getFirst(CASLoginProtocol.PGT_PARAM);
+
+        event.event(EventType.CODE_TO_TOKEN);
+
+        try {
+            checkSsl();
+            checkRealm();
+            checkTicket(pgt, CASLoginProtocol.PROXY_GRANTING_TICKET_PREFIX, false);
+            event.success();
+            return successResponse(getPT(this.session, clientSession, targetService));
+        } catch (CASValidationException e) {
+            return errorResponse(e);
+        }
+    }
+
+    protected Response successResponse(String pt) {
+        CASServiceResponse serviceResponse = ServiceResponseHelper.createProxySuccess(pt);
+        return prepare(Response.Status.OK, serviceResponse);
+    }
+
+    protected Response errorResponse(CASValidationException e) {
+        CASServiceResponse serviceResponse = ServiceResponseHelper.createProxyFailure(e.getError(), e.getErrorDescription());
+        return prepare(e.getStatus(), serviceResponse);
+    }
+
+    private Response prepare(Response.Status status, CASServiceResponse serviceResponse) {
+        MediaType responseMediaType = new ContentTypeHelper(session.getContext().getUri()).selectResponseType();
+        return ServiceResponseHelper.createResponse(status, responseMediaType, serviceResponse);
+    }
+}

--- a/src/main/java/org/keycloak/protocol/cas/endpoints/ProxyValidateEndpoint.java
+++ b/src/main/java/org/keycloak/protocol/cas/endpoints/ProxyValidateEndpoint.java
@@ -1,0 +1,73 @@
+package org.keycloak.protocol.cas.endpoints;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import java.util.Map;
+import org.jboss.resteasy.annotations.cache.NoCache;
+import org.keycloak.events.Errors;
+import org.keycloak.events.EventBuilder;
+import org.keycloak.events.EventType;
+import org.keycloak.models.*;
+import org.keycloak.protocol.cas.CASLoginProtocol;
+import org.keycloak.protocol.cas.representations.CASErrorCode;
+import org.keycloak.protocol.cas.representations.CASServiceResponse;
+import org.keycloak.protocol.cas.utils.CASValidationException;
+import org.keycloak.protocol.cas.utils.ContentTypeHelper;
+import org.keycloak.protocol.cas.utils.ServiceResponseHelper;
+
+public class ProxyValidateEndpoint extends AbstractValidateEndpoint {
+
+    public ProxyValidateEndpoint(KeycloakSession session,RealmModel realm, EventBuilder event) {
+        super(session, realm, event);
+    }
+
+    @GET
+    @NoCache
+    public Response build() {
+        MultivaluedMap<String, String> params = session.getContext().getUri().getQueryParameters();
+        String ticket = params.getFirst(CASLoginProtocol.TICKET_PARAM);
+        String pgtUrl = params.getFirst(CASLoginProtocol.PGTURL_PARAM);
+        boolean renew = params.containsKey(CASLoginProtocol.RENEW_PARAM);
+
+        event.event(EventType.CODE_TO_TOKEN);
+
+        try {
+            String prefix = ticket.startsWith(CASLoginProtocol.PROXY_TICKET_PREFIX)? CASLoginProtocol.PROXY_TICKET_PREFIX:(
+                ticket.startsWith(CASLoginProtocol.SERVICE_TICKET_PREFIX)? CASLoginProtocol.SERVICE_TICKET_PREFIX : null
+            );
+
+            if (prefix == null) {
+                event.error(Errors.INVALID_CODE);
+                throw new CASValidationException(CASErrorCode.INVALID_TICKET_SPEC, "Malformed service ticket", Response.Status.BAD_REQUEST);
+            }
+
+            checkSsl();
+            checkRealm();
+            checkTicket(ticket, prefix, renew);
+            if (pgtUrl != null) createProxyGrant(pgtUrl);
+            event.success();
+            return successResponse();
+        } catch (CASValidationException e) {
+            return errorResponse(e);
+        }
+    }
+
+    protected Response successResponse() {
+        UserSessionModel userSession = clientSession.getUserSession();
+        Map<String, Object> attributes = getUserAttributes();
+        CASServiceResponse serviceResponse = ServiceResponseHelper.createSuccess(userSession.getUser().getUsername(),attributes);
+        return prepare(Response.Status.OK, serviceResponse);
+    }
+
+    protected Response errorResponse(CASValidationException e) {
+        CASServiceResponse serviceResponse = ServiceResponseHelper.createFailure(e.getError(), e.getErrorDescription());
+        return prepare(e.getStatus(), serviceResponse);
+    }
+
+    private Response prepare(Response.Status status, CASServiceResponse serviceResponse) {
+        MediaType responseMediaType = new ContentTypeHelper(session.getContext().getUri()).selectResponseType();
+        return ServiceResponseHelper.createResponse(status, responseMediaType, serviceResponse);
+    }
+}

--- a/src/main/java/org/keycloak/protocol/cas/endpoints/SamlValidateEndpoint.java
+++ b/src/main/java/org/keycloak/protocol/cas/endpoints/SamlValidateEndpoint.java
@@ -56,7 +56,7 @@ public class SamlValidateEndpoint extends AbstractValidateEndpoint {
             String issuer = Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName());
             String ticket = getTicket(input);
 
-            checkTicket(ticket, renew);
+            checkTicket(ticket, CASLoginProtocol.SERVICE_TICKET_PREFIX, renew);
             UserModel user = clientSession.getUserSession().getUser();
 
             Map<String, Object> attributes = getUserAttributes();

--- a/src/main/java/org/keycloak/protocol/cas/endpoints/ServiceValidateEndpoint.java
+++ b/src/main/java/org/keycloak/protocol/cas/endpoints/ServiceValidateEndpoint.java
@@ -22,7 +22,7 @@ public class ServiceValidateEndpoint extends ValidateEndpoint {
     protected Response successResponse() {
         UserSessionModel userSession = clientSession.getUserSession();
         Map<String, Object> attributes = getUserAttributes();
-        CASServiceResponse serviceResponse = ServiceResponseHelper.createSuccess(userSession.getUser().getUsername(), attributes);
+        CASServiceResponse serviceResponse = ServiceResponseHelper.createSuccess(userSession.getUser().getUsername(), attributes, this.pgtIou, null);
         return prepare(Response.Status.OK, serviceResponse);
     }
 

--- a/src/main/java/org/keycloak/protocol/cas/endpoints/ValidateEndpoint.java
+++ b/src/main/java/org/keycloak/protocol/cas/endpoints/ValidateEndpoint.java
@@ -26,6 +26,7 @@ public class ValidateEndpoint extends AbstractValidateEndpoint {
     public Response build() {
         MultivaluedMap<String, String> params = session.getContext().getUri().getQueryParameters();
         String service = params.getFirst(CASLoginProtocol.SERVICE_PARAM);
+        String pgtUrl = params.getFirst(CASLoginProtocol.PGTURL_PARAM);
         String ticket = params.getFirst(CASLoginProtocol.TICKET_PARAM);
         boolean renew = params.containsKey(CASLoginProtocol.RENEW_PARAM);
 
@@ -36,7 +37,9 @@ public class ValidateEndpoint extends AbstractValidateEndpoint {
             checkRealm();
             checkClient(service);
 
-            checkTicket(ticket, renew);
+            checkTicket(ticket, CASLoginProtocol.SERVICE_TICKET_PREFIX, renew);
+
+            if (pgtUrl != null) createProxyGrant(pgtUrl);
 
             event.success();
             return successResponse();

--- a/src/main/java/org/keycloak/protocol/cas/representations/CASErrorCode.java
+++ b/src/main/java/org/keycloak/protocol/cas/representations/CASErrorCode.java
@@ -9,6 +9,8 @@ public enum CASErrorCode {
     UNAUTHORIZED_SERVICE_PROXY,
     /** The proxy callback specified is invalid. The credentials specified for proxy authentication do not meet the security requirements */
     INVALID_PROXY_CALLBACK,
+    /** The proxy callback specified return with error*/
+    PROXY_CALLBACK_ERROR,
     /** the ticket provided was not valid, or the ticket did not come from an initial login and renew was set on validation. */
     INVALID_TICKET,
     /** the ticket provided was valid, but the service specified did not match the service associated with the ticket. */

--- a/src/main/java/org/keycloak/protocol/cas/representations/CASServiceResponse.java
+++ b/src/main/java/org/keycloak/protocol/cas/representations/CASServiceResponse.java
@@ -6,6 +6,8 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 public class CASServiceResponse {
     private CASServiceResponseAuthenticationFailure authenticationFailure;
     private CASServiceResponseAuthenticationSuccess authenticationSuccess;
+    private CASServiceResponseProxySuccess proxySuccess;
+    private CASServiceResponseProxyFailure proxyFailure;
 
     public CASServiceResponseAuthenticationFailure getAuthenticationFailure() {
         return this.authenticationFailure;
@@ -21,5 +23,21 @@ public class CASServiceResponse {
 
     public void setAuthenticationSuccess(final CASServiceResponseAuthenticationSuccess authenticationSuccess) {
         this.authenticationSuccess = authenticationSuccess;
+    }
+
+    public CASServiceResponseProxySuccess getProxySuccess() {
+        return this.proxySuccess;
+    }
+
+    public void setProxySuccess(final CASServiceResponseProxySuccess proxySuccess) {
+        this.proxySuccess = proxySuccess;
+    }
+
+    public CASServiceResponseProxyFailure getProxyFailure() {
+        return this.proxyFailure;
+    }
+
+    public void setProxyFailure(final CASServiceResponseProxyFailure proxyFailure) {
+        this.proxyFailure = proxyFailure;
     }
 }

--- a/src/main/java/org/keycloak/protocol/cas/representations/CASServiceResponseProxyFailure.java
+++ b/src/main/java/org/keycloak/protocol/cas/representations/CASServiceResponseProxyFailure.java
@@ -1,0 +1,30 @@
+package org.keycloak.protocol.cas.representations;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlValue;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+public class CASServiceResponseProxyFailure {
+    @XmlAttribute
+    private String code;
+    @XmlValue
+    private String description;
+
+    public String getCode() {
+        return this.code;
+    }
+
+    public void setCode(final String code) {
+        this.code = code;
+    }
+
+    public String getDescription() {
+        return this.description;
+    }
+
+    public void setDescription(final String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/org/keycloak/protocol/cas/representations/CASServiceResponseProxySuccess.java
+++ b/src/main/java/org/keycloak/protocol/cas/representations/CASServiceResponseProxySuccess.java
@@ -1,0 +1,18 @@
+package org.keycloak.protocol.cas.representations;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+
+
+@XmlAccessorType(XmlAccessType.FIELD)
+public class CASServiceResponseProxySuccess {
+    private String proxyTicket;
+
+    public String getProxyTicket() {
+        return this.proxyTicket;
+    }
+
+    public void setProxyTicket(final String proxyTicket) {
+        this.proxyTicket = proxyTicket;
+    }
+}

--- a/src/main/java/org/keycloak/protocol/cas/utils/AttributesMapAdapter.java
+++ b/src/main/java/org/keycloak/protocol/cas/utils/AttributesMapAdapter.java
@@ -39,7 +39,7 @@ public final class AttributesMapAdapter extends XmlAdapter<AttributesMapAdapter.
             this.elements = new ArrayList<>();
             for (Map.Entry<String, Object> entry : attributes.entrySet()) {
                 if (entry.getValue() instanceof Collection) {
-                    for (Object item : ((Collection) entry.getValue())) {
+                    for (Object item : ((Collection<?>) entry.getValue())) {
                         addElement(entry.getKey(), item);
                     }
                 } else {

--- a/src/main/java/org/keycloak/protocol/cas/utils/CASValidationException.java
+++ b/src/main/java/org/keycloak/protocol/cas/utils/CASValidationException.java
@@ -5,6 +5,7 @@ import jakarta.ws.rs.core.Response;
 import org.keycloak.protocol.cas.representations.CASErrorCode;
 
 public class CASValidationException extends WebApplicationException {
+    private static final long serialVersionUID = 4929825917145240776L;
     private final CASErrorCode error;
     private final String errorDescription;
     private final Response.Status status;

--- a/src/main/java/org/keycloak/protocol/cas/utils/ServiceResponseHelper.java
+++ b/src/main/java/org/keycloak/protocol/cas/utils/ServiceResponseHelper.java
@@ -7,6 +7,8 @@ import org.keycloak.protocol.cas.representations.CASErrorCode;
 import org.keycloak.protocol.cas.representations.CASServiceResponse;
 import org.keycloak.protocol.cas.representations.CASServiceResponseAuthenticationFailure;
 import org.keycloak.protocol.cas.representations.CASServiceResponseAuthenticationSuccess;
+import org.keycloak.protocol.cas.representations.CASServiceResponseProxySuccess;
+import org.keycloak.protocol.cas.representations.CASServiceResponseProxyFailure;
 
 import java.util.List;
 import java.util.Map;
@@ -39,6 +41,24 @@ public final class ServiceResponseHelper {
         failure.setCode(errorCode == null ? CASErrorCode.INTERNAL_ERROR.name() : errorCode.name());
         failure.setDescription(errorDescription);
         response.setAuthenticationFailure(failure);
+
+        return response;
+    }
+
+    public static CASServiceResponse createProxySuccess(String pt) {
+        CASServiceResponse response = new CASServiceResponse();
+        CASServiceResponseProxySuccess success = new CASServiceResponseProxySuccess();
+        success.setProxyTicket(pt);
+        response.setProxySuccess(success);
+        return response;
+    }
+
+    public static CASServiceResponse createProxyFailure(CASErrorCode errorCode, String errorDescription) {
+        CASServiceResponse response = new CASServiceResponse();
+        CASServiceResponseProxyFailure failure = new CASServiceResponseProxyFailure();
+        failure.setCode(errorCode == null ? CASErrorCode.INTERNAL_ERROR.name() : errorCode.name());
+        failure.setDescription(errorDescription);
+        response.setProxyFailure(failure);
 
         return response;
     }

--- a/src/test/java/org/keycloak/protocol/cas/ServiceResponseTest.java
+++ b/src/test/java/org/keycloak/protocol/cas/ServiceResponseTest.java
@@ -52,10 +52,10 @@ public class ServiceResponseTest {
         assertEquals("username", xpath.evaluate("/cas:serviceResponse/cas:authenticationSuccess/cas:user", doc));
         int idx = 0;
         for (Node node : xpath.selectNodes("/cas:serviceResponse/cas:authenticationSuccess/cas:attributes/cas:list", doc)) {
-            assertEquals(((List)attributes.get("list")).get(idx), node.getTextContent());
+            assertEquals(((List<?>)attributes.get("list")).get(idx), node.getTextContent());
             idx++;
         }
-        assertEquals(((List)attributes.get("list")).size(), idx);
+        assertEquals(((List<?>)attributes.get("list")).size(), idx);
         assertEquals(attributes.get("int").toString(), xpath.evaluate("/cas:serviceResponse/cas:authenticationSuccess/cas:attributes/cas:int", doc));
         assertEquals(attributes.get("string").toString(), xpath.evaluate("/cas:serviceResponse/cas:authenticationSuccess/cas:attributes/cas:string", doc));
 


### PR DESCRIPTION
Issue #37

Changelog:
**/serviceValidate** and **/p3/serviceValidate** with optional parameter "pgtUrl" create PGT and PGTIOU ticket, return a proxyGrantingTicket(PGTIOU).
**/proxy** receive a PGT ticket and exchange it for a PT ticket.
**/proxyValidate** and **/p3/proxyValidate** check if a PT ticket is valid.

Note: OAuth2CodeParser is not used because the PGT ticker is reusable, keycloak 23.0.0 and above generate an error.